### PR TITLE
Log brightness percent and Kelvin values

### DIFF
--- a/src/main/java/at/sv/hue/FormatUtil.java
+++ b/src/main/java/at/sv/hue/FormatUtil.java
@@ -1,0 +1,15 @@
+package at.sv.hue;
+
+public final class FormatUtil {
+    private FormatUtil() {
+    }
+
+    public static String formatBrightnessPercent(int bri) {
+        double percent = ((bri - 1) * 99.0 / 253.0) + 1.0;
+        double roundedOneDecimal = Math.round(percent * 10.0) / 10.0;
+        if (Math.abs(roundedOneDecimal - Math.rint(roundedOneDecimal)) < 0.0001) {
+            return String.valueOf((int) Math.rint(roundedOneDecimal));
+        }
+        return String.format(java.util.Locale.ROOT, "%.1f", roundedOneDecimal);
+    }
+}

--- a/src/main/java/at/sv/hue/ScheduledState.java
+++ b/src/main/java/at/sv/hue/ScheduledState.java
@@ -413,8 +413,8 @@ public final class ScheduledState { // todo: a better name would be StateDefinit
                (temporary && !retryAfterPowerOnState ? ", temporary" : "") +
                (retryAfterPowerOnState ? ", power-on-state" : "") +
                getFormattedPropertyIfSet("on", on) +
-               getFormattedPropertyIfSet("bri", brightness) +
-               getFormattedPropertyIfSet("ct", ct) +
+               getFormattedBriIfSet() +
+               getFormattedCtIfSet() +
                getFormattedPropertyIfSet("x", x) +
                getFormattedPropertyIfSet("y", y) +
                getFormattedPropertyIfSet("hue", hue) +
@@ -451,6 +451,17 @@ public final class ScheduledState { // todo: a better name would be StateDefinit
 
     private String formatPropertyName(String name) {
         return ", " + name + "=";
+    }
+
+    private String getFormattedBriIfSet() {
+        if (brightness == null) return "";
+        return formatPropertyName("bri") + brightness + " (" + FormatUtil.formatBrightnessPercent(brightness) + "%)";
+    }
+
+    private String getFormattedCtIfSet() {
+        if (ct == null) return "";
+        long kelvin = Math.round(1_000_000.0 / ct);
+        return formatPropertyName("ct") + ct + " (" + kelvin + "K)";
     }
 
     private String getFormattedDaysOfWeek() {

--- a/src/main/java/at/sv/hue/api/PutCall.java
+++ b/src/main/java/at/sv/hue/api/PutCall.java
@@ -1,6 +1,7 @@
 package at.sv.hue.api;
 
 import at.sv.hue.ColorMode;
+import at.sv.hue.FormatUtil;
 import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -54,8 +55,8 @@ public final class PutCall {
         return "PutCall {" +
                "id=" + id +
                getFormattedPropertyIfSet("on", on) +
-               getFormattedPropertyIfSet("bri", bri) +
-               getFormattedPropertyIfSet("ct", ct) +
+               getFormattedBriIfSet() +
+               getFormattedCtIfSet() +
                getFormattedPropertyIfSet("x", x) +
                getFormattedPropertyIfSet("y", y) +
                getFormattedPropertyIfSet("hue", hue) +
@@ -69,6 +70,17 @@ public final class PutCall {
     private String getFormattedPropertyIfSet(String name, Object property) {
         if (property == null) return "";
         return formatPropertyName(name) + property;
+    }
+
+    private String getFormattedBriIfSet() {
+        if (bri == null) return "";
+        return formatPropertyName("bri") + bri + " (" + FormatUtil.formatBrightnessPercent(bri) + "%)";
+    }
+
+    private String getFormattedCtIfSet() {
+        if (ct == null) return "";
+        long kelvin = Math.round(1_000_000.0 / ct);
+        return formatPropertyName("ct") + ct + " (" + kelvin + "K)";
     }
 
     private String formatPropertyName(String name) {

--- a/src/test/java/at/sv/hue/HueSchedulerTest.java
+++ b/src/test/java/at/sv/hue/HueSchedulerTest.java
@@ -3553,6 +3553,11 @@ class HueSchedulerTest {
     }
 
     @Test
+    void parse_canHandleBrightnessInPercent_alsoDoubleValues2() {
+        assertAppliedBrightness("10.89%", 26);
+    }
+
+    @Test
     void parse_canHandleBrightnessInPercent_maxValue() {
         assertAppliedBrightness("100%", 254);
     }


### PR DESCRIPTION
Fixes #32

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Brightness now displays with a percentage alongside the raw value, with smart rounding (integer or one decimal).
  - Color temperature displays the corresponding Kelvin value alongside the raw ct.
- Refactor
  - Streamlined formatting logic for brightness and color temperature in outputs.
- Tests
  - Added tests to validate parsing of brightness percentages, including decimal inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->